### PR TITLE
As should accept react element

### DIFF
--- a/lib/progressive-table.js
+++ b/lib/progressive-table.js
@@ -15,24 +15,26 @@ type State = {
 };
 
 type AsableProps = {
-  as: React.ComponentType<any> | React.Element<any>,
+  as: React.ElementType | React.Element<any>,
   children: React.Node,
   [string]: any
 };
 
 const generateAsableComponent = (defaultAs: string) => {
-  const AsableComponent = (props: AsableProps) => {
+  const AsableComponent = (props: AsableProps): React.Node => {
     const { as, ...rest } = props;
     let Component;
 
     if (React.isValidElement(as)) {
+      // $FlowFixMe
       Component = as.type;
+      // $FlowFixMe
       Object.assign(rest, as.props);
     } else {
       Component = as;
     }
 
-    return (
+    return /* $FlowFixMe */ (
       <Component {...rest}>{rest.children}</Component>
     );
   };

--- a/lib/progressive-table.js
+++ b/lib/progressive-table.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import { renderAs } from 'react-render-as';
 
 /** @memberOf ProgressiveTable */
 type Props = {
@@ -20,45 +21,18 @@ type AsableProps = {
   [string]: any
 };
 
-const generateAsableComponent = (defaultAs: string) => {
-  const AsableComponent = (props: AsableProps): React.Node => {
-    const { as, ...rest } = props;
-    let Component;
-
-    if (React.isValidElement(as)) {
-      // $FlowFixMe
-      Component = as.type;
-      // $FlowFixMe
-      Object.assign(rest, as.props);
-    } else {
-      Component = as;
-    }
-
-    return /* $FlowFixMe */ (
-      <Component {...rest}>{rest.children}</Component>
-    );
-  };
-
-  AsableComponent.displayName = `ProgressiveTable(${defaultAs})`;
-  AsableComponent.defaultProps = {
-    as: defaultAs
-  };
-
-  return AsableComponent;
-};
-
 export default class ProgressiveTable extends React.Component<Props, State> {
   static defaultProps = {
     minimumRender: 16,
     nextRenderIncrement: 1
   };
 
-  static Row = generateAsableComponent('tr');
-  static Cell = generateAsableComponent('td');
-  static HeaderCell = generateAsableComponent('th');
-  static Header = generateAsableComponent('thead');
-  static Body = generateAsableComponent('tbody');
-  static Table = generateAsableComponent('table');
+  static Row = renderAs('tr');
+  static Cell = renderAs('td');
+  static HeaderCell = renderAs('th');
+  static Header = renderAs('thead');
+  static Body = renderAs('tbody');
+  static Table = renderAs('table');
 
   minHeight: number = 0;
   timer: TimeoutID;

--- a/lib/progressive-table.js
+++ b/lib/progressive-table.js
@@ -15,7 +15,7 @@ type State = {
 };
 
 type AsableProps = {
-  as: React.ComponentType<any> | React.Element<>,
+  as: React.ComponentType<any> | React.Element<any>,
   children: React.Node,
   [string]: any
 };

--- a/lib/progressive-table.js
+++ b/lib/progressive-table.js
@@ -15,7 +15,7 @@ type State = {
 };
 
 type AsableProps = {
-  as: React.ComponentType<any>,
+  as: React.ComponentType<any> | React.Element<>,
   children: React.Node,
   [string]: any
 };
@@ -23,10 +23,17 @@ type AsableProps = {
 const generateAsableComponent = (defaultAs: string) => {
   const AsableComponent = (props: AsableProps) => {
     const { as, ...rest } = props;
-    const Component = as;
+    let Component;
+
+    if (React.isValidElement(as)) {
+      Component = as.type;
+      Object.assign(rest, as.props);
+    } else {
+      Component = as;
+    }
 
     return (
-      <Component {...rest} />
+      <Component {...rest}>{rest.children}</Component>
     );
   };
 

--- a/lib/progressive-table.js
+++ b/lib/progressive-table.js
@@ -15,12 +15,6 @@ type State = {
   minimumRender: number
 };
 
-type AsableProps = {
-  as: React.ElementType | React.Element<any>,
-  children: React.Node,
-  [string]: any
-};
-
 export default class ProgressiveTable extends React.Component<Props, State> {
   static defaultProps = {
     minimumRender: 16,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9495,6 +9495,11 @@
         "prop-types": "^15.6.0"
       }
     },
+    "react-render-as": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/react-render-as/-/react-render-as-0.1.0.tgz",
+      "integrity": "sha512-wtxvrapk5LUB+X0V0gY8V8F8G3Lm2C5YqSMZTnx6UNbPnmT1hwxBcl7yzQGp03OwerGlih8/oU4cv8osuSfF/w=="
+    },
     "react-test-renderer": {
       "version": "16.4.0",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.4.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,6 +105,16 @@
         }
       }
     },
+    "@babel/runtime": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.51.tgz",
+      "integrity": "sha1-SLjtGDBwNMZiD2Q1FGUMoszAFlo=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.5.7",
+        "regenerator-runtime": "^0.11.1"
+      }
+    },
     "@babel/template": {
       "version": "7.0.0-beta.44",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
@@ -2421,6 +2431,12 @@
           }
         }
       }
+    },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
+      "dev": true
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -7473,6 +7489,12 @@
         "array-includes": "^3.0.3"
       }
     },
+    "keyboard-key": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/keyboard-key/-/keyboard-key-1.0.1.tgz",
+      "integrity": "sha512-OAfjaSI917BOonwfH6LQHMZJRv5035jjZvgElouB/DM4I7l5zEjrA15RD80YwIjhN69xqEfWCZIbhBcGpb85Ig==",
+      "dev": true
+    },
     "keyv": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
@@ -10112,6 +10134,20 @@
       "resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
       "integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg=",
       "dev": true
+    },
+    "semantic-ui-react": {
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-0.81.1.tgz",
+      "integrity": "sha512-ooLjHxSkLsjWkOlXxLsZzeaCBy8fjanpUwkJNhzVj6t8XC8qcK2Y57GetC2bMdyx6ewUL9DOHZfoybwfjUG9ZA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.0.0-beta.49",
+        "classnames": "^2.2.5",
+        "fbjs": "^0.8.16",
+        "keyboard-key": "^1.0.1",
+        "lodash": "^4.17.10",
+        "prop-types": "^15.6.1"
+      }
     },
     "semver": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -80,5 +80,8 @@
     "stryker-jest-runner": "^0.6.0",
     "webpack": "^4.8.1",
     "webpack-cli": "^2.1.3"
+  },
+  "dependencies": {
+    "react-render-as": "^0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "jest-enzyme": "^6.0.1",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
+    "semantic-ui-react": "^0.81.1",
     "stryker": "^0.23.0",
     "stryker-api": "^0.17.0",
     "stryker-babel-transpiler": "^0.5.0",

--- a/test/spec/progressive-table.js
+++ b/test/spec/progressive-table.js
@@ -3,6 +3,7 @@ import React from 'react';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import 'jest-enzyme';
+import { Table } from 'semantic-ui-react';
 import ProgressiveTable from '../../lib/progressive-table';
 
 Enzyme.configure({ adapter: new Adapter() });
@@ -45,14 +46,14 @@ describe('ProgressiveTable', () => {
     </ProgressiveTable.Table>
   );
 
-  const setupComponent = (overrides = {}) => {
+  const setupComponent = (overrides = {}, children = getChildren()) => {
     mockProps = {
       ...getRequiredProps(),
       ...overrides
     };
 
     component = mount((
-      <ProgressiveTable {...mockProps}>{getChildren()}</ProgressiveTable>
+      <ProgressiveTable {...mockProps}>{children}</ProgressiveTable>
     ));
 
     instance = component.instance();
@@ -69,6 +70,65 @@ describe('ProgressiveTable', () => {
 
   const tableRows = () => component.find(ProgressiveTable.Row);
   const minHeight = () => component.find('div').instance().style.minHeight;
+
+  describe('asable components', () => {
+    describe('when setting as props to semantic-ui table components', () => {
+      const table = () => component.find(Table);
+      const header = () => component.find(Table.Header);
+      const headerRow = () => header().find(Table.Row);
+      const headerCell = () => headerRow().find(Table.HeaderCell);
+      const body = () => component.find(Table.Body);
+      const bodyRow = () => body().find(Table.Row);
+      const bodyCell = () => bodyRow().find(Table.Cell);
+
+      beforeEach(() => {
+        setupComponent({ minimumRender: 10 }, (
+          <ProgressiveTable.Table as={Table}>
+            <ProgressiveTable.Header as={Table.Header}>
+              <ProgressiveTable.Row as={Table.Row}>
+                <ProgressiveTable.HeaderCell as={Table.HeaderCell}>Dave</ProgressiveTable.HeaderCell>
+              </ProgressiveTable.Row>
+            </ProgressiveTable.Header>
+            <ProgressiveTable.Body as={Table.Body}>
+              <ProgressiveTable.Row as={Table.Row}>
+                <ProgressiveTable.Cell as={Table.Cell}>foo</ProgressiveTable.Cell>
+              </ProgressiveTable.Row>
+            </ProgressiveTable.Body>
+          </ProgressiveTable.Table>
+        ));
+      });
+
+      it('renders the table correctly', () => {
+        expect(table()).toHaveLength(1);
+      });
+
+      it('renders the header correctly', () => {
+        expect(header()).toHaveLength(1);
+      });
+
+      it('renders the body correctly', () => {
+        expect(body()).toHaveLength(1);
+      });
+
+      it('renders the header rows correctly', () => {
+        expect(headerRow()).toHaveLength(1);
+      });
+
+      it('renders the body rows correctly', () => {
+        expect(bodyRow()).toHaveLength(1);
+      });
+
+      it('renders the header cells correctly', () => {
+        expect(headerCell()).toHaveLength(1);
+        expect(headerCell()).toHaveText('Dave');
+      });
+
+      it('renders the body cells correctly', () => {
+        expect(bodyCell()).toHaveLength(1);
+        expect(bodyCell()).toHaveText('foo');
+      });
+    });
+  });
 
   describe('before timers have completed', () => {
     it('renders only the first minimumRender rows', () => {

--- a/test/spec/progressive-table.js
+++ b/test/spec/progressive-table.js
@@ -72,32 +72,15 @@ describe('ProgressiveTable', () => {
   const minHeight = () => component.find('div').instance().style.minHeight;
 
   describe('asable components', () => {
-    describe('when setting as props to semantic-ui table components', () => {
-      const table = () => component.find(Table);
-      const header = () => component.find(Table.Header);
-      const headerRow = () => header().find(Table.Row);
-      const headerCell = () => headerRow().find(Table.HeaderCell);
-      const body = () => component.find(Table.Body);
-      const bodyRow = () => body().find(Table.Row);
-      const bodyCell = () => bodyRow().find(Table.Cell);
+    const table = () => component.find(Table);
+    const header = () => component.find(Table.Header);
+    const headerRow = () => header().find(Table.Row);
+    const headerCell = () => headerRow().find(Table.HeaderCell);
+    const body = () => component.find(Table.Body);
+    const bodyRow = () => body().find(Table.Row);
+    const bodyCell = () => bodyRow().find(Table.Cell);
 
-      beforeEach(() => {
-        setupComponent({ minimumRender: 10 }, (
-          <ProgressiveTable.Table as={Table}>
-            <ProgressiveTable.Header as={Table.Header}>
-              <ProgressiveTable.Row as={Table.Row}>
-                <ProgressiveTable.HeaderCell as={Table.HeaderCell}>Dave</ProgressiveTable.HeaderCell>
-              </ProgressiveTable.Row>
-            </ProgressiveTable.Header>
-            <ProgressiveTable.Body as={Table.Body}>
-              <ProgressiveTable.Row as={Table.Row}>
-                <ProgressiveTable.Cell as={Table.Cell}>foo</ProgressiveTable.Cell>
-              </ProgressiveTable.Row>
-            </ProgressiveTable.Body>
-          </ProgressiveTable.Table>
-        ));
-      });
-
+    const renderStructureTests = () => {
       it('renders the table correctly', () => {
         expect(table()).toHaveLength(1);
       });
@@ -127,6 +110,62 @@ describe('ProgressiveTable', () => {
         expect(bodyCell()).toHaveLength(1);
         expect(bodyCell()).toHaveText('foo');
       });
+    };
+
+    describe('when setting as props to semantic-ui table elements', () => {
+      beforeEach(() => {
+        setupComponent(
+          { minimumRender: 10 },
+          (
+            <ProgressiveTable.Table as={<Table as="div" />}>
+              <ProgressiveTable.Header as={<Table.Header />}>
+                <ProgressiveTable.Row as={<Table.Row />}>
+                  <ProgressiveTable.HeaderCell as={<Table.HeaderCell />}>Dave</ProgressiveTable.HeaderCell>
+                </ProgressiveTable.Row>
+              </ProgressiveTable.Header>
+              <ProgressiveTable.Body as={<Table.Body />}>
+                <ProgressiveTable.Row as={<Table.Row />}>
+                  <ProgressiveTable.Cell as={<Table.Cell />}>foo</ProgressiveTable.Cell>
+                </ProgressiveTable.Row>
+              </ProgressiveTable.Body>
+            </ProgressiveTable.Table>
+          )
+        );
+      });
+
+      renderStructureTests();
+
+      it('passes props to the asable component', () => {
+        expect(table()).toHaveProp('as', 'div');
+      });
+
+      it('renders asable components as prop passed to element in as prop', () => {
+        expect(table().find('div')).toHaveLength(1);
+      });
+    });
+
+    describe('when setting as props to semantic-ui table components', () => {
+      beforeEach(() => {
+        setupComponent(
+          { minimumRender: 10 },
+          (
+            <ProgressiveTable.Table as={Table}>
+              <ProgressiveTable.Header as={Table.Header}>
+                <ProgressiveTable.Row as={Table.Row}>
+                  <ProgressiveTable.HeaderCell as={Table.HeaderCell}>Dave</ProgressiveTable.HeaderCell>
+                </ProgressiveTable.Row>
+              </ProgressiveTable.Header>
+              <ProgressiveTable.Body as={Table.Body}>
+                <ProgressiveTable.Row as={Table.Row}>
+                  <ProgressiveTable.Cell as={Table.Cell}>foo</ProgressiveTable.Cell>
+                </ProgressiveTable.Row>
+              </ProgressiveTable.Body>
+            </ProgressiveTable.Table>
+          )
+        );
+      });
+
+      renderStructureTests();
     });
   });
 


### PR DESCRIPTION
This changes `ProgressiveTable` so it can accept JSX in the `as` prop of asable components, to allow props to be passed to these components when they render.

It also adds in some tests for the existing functionality for `as` props, i.e. when passing react components.

This logic has also been moved to a new package: `react-render-as`