### PR TITLE
Remove need for render-as dependency and bump to version 1.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 1.0.0
+
+* Removed dependency on react-render-as
+* Removed pseudo elements in favour of a `tr` prop
+* Increased coverage to 100%
+* Increased mutation threshold to 100%
+
 ## 0.1.2
 
 * Fix whole table re-rendering despite new children being set

--- a/README.md
+++ b/README.md
@@ -25,28 +25,28 @@ import ProgressiveTable from 'react-progressive-table';
 
 const MyComponent = () => (
   <ProgressiveTable>
-    <ProgressiveTable.Table>
-      <ProgressiveTable.Header>
-        <ProgressiveTable.Row>
-          <ProgressiveTable.HeaderCell>
+    <table>
+      <thead>
+        <tr>
+          <th>
             Foo
-          </ProgressiveTable.HeaderCell>
-          <ProgressiveTable.HeaderCell>
+          </th>
+          <th>
             Bar
-          </ProgressiveTable.HeaderCell>
-        </ProgressiveTable.Row>
-      </ProgressiveTable.Header>
-      <ProgressiveTable.Body>
-        <ProgressiveTable.Row>
-          <ProgressiveTable.Cell>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
             53
-          </ProgressiveTable.Cell>
-          <ProgressiveTable.Cell>
+          </td>
+          <td>
             42
-          </ProgressiveTable.Cell>
-        </ProgressiveTable.Row>
-      </ProgressiveTable.Body>
-    </ProgressiveTable.Table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </ProgressiveTable>
 );
 ```
@@ -58,29 +58,29 @@ import ProgressiveTable from 'react-progressive-table';
 import { Table } from 'semantic-ui-react';
 
 const MyComponent = () => (
-  <ProgressiveTable>
-    <ProgressiveTable.Table as={Table}>
-      <ProgressiveTable.Header as={Table.Header>>
-        <ProgressiveTable.Row as={Table.Row}>
-          <ProgressiveTable.HeaderCell as={Table.HeaderCell}>
+  <ProgressiveTable tr={Table.Row}>
+    <Table>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>
             Foo
-          </ProgressiveTable.HeaderCell>
-          <ProgressiveTable.HeaderCell as={Table.HeaderCell}>
+          </Table.HeaderCell>
+          <Table.HeaderCell>
             Bar
-          </ProgressiveTable.HeaderCell>
-        </ProgressiveTable.Row>
-      </ProgressiveTable.Header>
-      <ProgressiveTable.Body as={Table.Body}>
-        <ProgressiveTable.Row as={Table.Row}>
-          <ProgressiveTable.Cell as={Table.Cell}>
+          </Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>
             53
-          </ProgressiveTable.Cell>
-          <ProgressiveTable.Cell as={Table.Cell}>
+          </Table.Cell>
+          <Table.Cell>
             42
-          </ProgressiveTable.Cell>
-        </ProgressiveTable.Row>
-      </ProgressiveTable.Body>
-    </ProgressiveTable.Table>
+          </Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table>
   </ProgressiveTable>
 );
 ```

--- a/lib/progressive-table.js
+++ b/lib/progressive-table.js
@@ -60,7 +60,7 @@ export default class ProgressiveTable extends React.Component<Props, State> {
       this.element.style.minHeight = `${this.minHeight}px`;
 
       this.timer = setTimeout(this.renderNextRow, 0);
-    } else if (this.element) {
+    } else {
       this.element.style.minHeight = '0px';
       this.minHeight = this.element.offsetHeight;
     }

--- a/lib/progressive-table.js
+++ b/lib/progressive-table.js
@@ -1,12 +1,12 @@
 // @flow
 import * as React from 'react';
-import { renderAs } from 'react-render-as';
 
 /** @memberOf ProgressiveTable */
 type Props = {
   children: React.Node,
   minimumRender: number,
-  nextRenderIncrement: number
+  nextRenderIncrement: number,
+  tr: React.ElementType
 };
 
 /** @memberOf ProgressiveTable */
@@ -19,15 +19,9 @@ type State = {
 export default class ProgressiveTable extends React.Component<Props, State> {
   static defaultProps = {
     minimumRender: 16,
-    nextRenderIncrement: 1
+    nextRenderIncrement: 1,
+    tr: 'tr'
   };
-
-  static Row = renderAs('tr');
-  static Cell = renderAs('td');
-  static HeaderCell = renderAs('th');
-  static Header = renderAs('thead');
-  static Body = renderAs('tbody');
-  static Table = renderAs('table');
 
   minHeight: number = 0;
   timer: TimeoutID;
@@ -86,7 +80,9 @@ export default class ProgressiveTable extends React.Component<Props, State> {
 
   renderChildren(children: React.Node): React.Node {
     return React.Children.toArray(children).map((node) => {
-      if (this.constructor.Row === node.type) {
+      if (!node || !node.type) return node;
+
+      if (this.props.tr === node.type) {
         return this.currentRow++ < this.state.row ? node : null;
       }
 

--- a/lib/progressive-table.js
+++ b/lib/progressive-table.js
@@ -53,9 +53,9 @@ export default class ProgressiveTable extends React.Component<Props, State> {
   }
 
   shouldRenderNextRow() {
-    if (this.timer) clearTimeout(this.timer);
+    clearTimeout(this.timer);
 
-    if (this.state.row <= this.currentRow && this.element) {
+    if (this.state.row <= this.currentRow) {
       this.minHeight = Math.max(this.minHeight, this.element.offsetHeight);
       this.element.style.minHeight = `${this.minHeight}px`;
 
@@ -67,7 +67,7 @@ export default class ProgressiveTable extends React.Component<Props, State> {
   }
 
   componentWillUnmount() {
-    if (this.timer) clearTimeout(this.timer);
+    clearTimeout(this.timer);
   }
 
   renderNextRow = (): void => {
@@ -75,7 +75,7 @@ export default class ProgressiveTable extends React.Component<Props, State> {
   }
 
   setElement = (el: HTMLElement | null) => {
-    if (el) this.element = el;
+    this.element = ((el: any): HTMLElement);
   };
 
   renderChildren(children: React.Node): React.Node {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-progressive-table",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9494,11 +9494,6 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.0"
       }
-    },
-    "react-render-as": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/react-render-as/-/react-render-as-0.1.1.tgz",
-      "integrity": "sha512-6qdUvQLiRd6GTcaWbZ/DLc6kn1xKDZNi/3WEPa3fdAnjn2RkKFkqgYNKwBXClcAFwFaT8RWBSv1Mzv9EKYcclA=="
     },
     "react-test-renderer": {
       "version": "16.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-progressive-table",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9496,9 +9496,9 @@
       }
     },
     "react-render-as": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/react-render-as/-/react-render-as-0.1.0.tgz",
-      "integrity": "sha512-wtxvrapk5LUB+X0V0gY8V8F8G3Lm2C5YqSMZTnx6UNbPnmT1hwxBcl7yzQGp03OwerGlih8/oU4cv8osuSfF/w=="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/react-render-as/-/react-render-as-0.1.1.tgz",
+      "integrity": "sha512-6qdUvQLiRd6GTcaWbZ/DLc6kn1xKDZNi/3WEPa3fdAnjn2RkKFkqgYNKwBXClcAFwFaT8RWBSv1Mzv9EKYcclA=="
     },
     "react-test-renderer": {
       "version": "16.4.0",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "author": "Sam Boylett <sam.boylett@piksel.com>",
   "main": "dist/index.js",
   "scripts": {
-    "prepublishOnly": "NODE_ENV=production npm run build -- --optimize-minimize",
-    "build": "webpack --bail --progress --profile",
+    "prepublishOnly": "npm run build",
+    "build": "webpack",
     "lint": "eslint lib && eslint test/spec",
     "flow": "./node_modules/.bin/flow",
     "test": "NODE_ENV=test jest --coverage",
@@ -29,7 +29,7 @@
     "coverageThreshold": {
       "global": {
         "statements": 100,
-        "branches": 95,
+        "branches": 100,
         "lines": 100,
         "functions": 100
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-progressive-table",
   "description": "Utility component for rendering table rows progressively",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "author": "Sam Boylett <sam.boylett@piksel.com>",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -80,8 +80,5 @@
     "stryker-jest-runner": "^0.6.0",
     "webpack": "^4.8.1",
     "webpack-cli": "^2.1.3"
-  },
-  "dependencies": {
-    "react-render-as": "^0.1.0"
   }
 }

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -7,6 +7,7 @@ module.exports = (config) => {
     testRunner: 'jest',
     mutator: 'javascript',
     coverageAnalysis: 'off',
+    maxConcurrentTestRunners: 6,
     plugins: [
       'stryker-jest-runner',
       'stryker-html-reporter',

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -18,6 +18,11 @@ module.exports = (config) => {
     reporter: ['dots', 'clear-text', 'html'],
     htmlReporter: {
       baseDir: 'test/results/mutation/html'
-    }
+    },
+     thresholds: {
+       high: 100,
+       low: 100,
+       break: 100
+     }
   });
 };

--- a/test/spec/progressive-table.js
+++ b/test/spec/progressive-table.js
@@ -174,6 +174,16 @@ describe('ProgressiveTable', () => {
     it('has a minimum height of 0', () => {
       expect(minHeight()).toEqual('0px');
     });
+
+    describe('when component unmounts', () => {
+      beforeEach(() => {
+        component.unmount();
+      });
+
+      it('clears the timer', () => {
+        expect(clearTimeout).toHaveBeenCalledWith(instance.timer);
+      });
+    });
   });
 
   describe('after first timer completed', () => {

--- a/test/spec/progressive-table.js
+++ b/test/spec/progressive-table.js
@@ -18,32 +18,32 @@ describe('ProgressiveTable', () => {
   });
 
   const getChildren = () => (
-    <ProgressiveTable.Table>
-      <ProgressiveTable.Header>
-        <ProgressiveTable.Row>
-          <ProgressiveTable.HeaderCell>Dave</ProgressiveTable.HeaderCell>
-          <ProgressiveTable.HeaderCell>Jamie</ProgressiveTable.HeaderCell>
-          <ProgressiveTable.HeaderCell>Joe</ProgressiveTable.HeaderCell>
-        </ProgressiveTable.Row>
-      </ProgressiveTable.Header>
-      <ProgressiveTable.Body>
-        <ProgressiveTable.Row>
-          <ProgressiveTable.Cell>foo</ProgressiveTable.Cell>
-          <ProgressiveTable.Cell>bar</ProgressiveTable.Cell>
-          <ProgressiveTable.Cell>Bam</ProgressiveTable.Cell>
-        </ProgressiveTable.Row>
-        <ProgressiveTable.Row>
-          <ProgressiveTable.Cell>whizz</ProgressiveTable.Cell>
-          <ProgressiveTable.Cell>woop</ProgressiveTable.Cell>
-          <ProgressiveTable.Cell>binary star system</ProgressiveTable.Cell>
-        </ProgressiveTable.Row>
-        <ProgressiveTable.Row>
-          <ProgressiveTable.Cell>1</ProgressiveTable.Cell>
-          <ProgressiveTable.Cell>2</ProgressiveTable.Cell>
-          <ProgressiveTable.Cell>3m</ProgressiveTable.Cell>
-        </ProgressiveTable.Row>
-      </ProgressiveTable.Body>
-    </ProgressiveTable.Table>
+    <table>
+      <thead>
+        <tr>
+          <th>Dave</th>
+          <th>Jamie</th>
+          <th>Joe</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>foo</td>
+          <td>bar</td>
+          <td>Bam</td>
+        </tr>
+        <tr>
+          <td>whizz</td>
+          <td>woop</td>
+          <td>binary star system</td>
+        </tr>
+        <tr>
+          <td>1</td>
+          <td>2</td>
+          <td>3m</td>
+        </tr>
+      </tbody>
+    </table>
   );
 
   const setupComponent = (overrides = {}, children = getChildren()) => {
@@ -68,10 +68,10 @@ describe('ProgressiveTable', () => {
     component.unmount();
   });
 
-  const tableRows = () => component.find(ProgressiveTable.Row);
+  const tableRows = () => component.find('tr');
   const minHeight = () => component.find('div').instance().style.minHeight;
 
-  describe('asable components', () => {
+  describe('component structure', () => {
     const table = () => component.find(Table);
     const header = () => component.find(Table.Header);
     const headerRow = () => header().find(Table.Row);
@@ -117,31 +117,23 @@ describe('ProgressiveTable', () => {
         setupComponent(
           { minimumRender: 10 },
           (
-            <ProgressiveTable.Table as={<Table as="div" />}>
-              <ProgressiveTable.Header as={<Table.Header />}>
-                <ProgressiveTable.Row as={<Table.Row />}>
-                  <ProgressiveTable.HeaderCell as={<Table.HeaderCell />}>Dave</ProgressiveTable.HeaderCell>
-                </ProgressiveTable.Row>
-              </ProgressiveTable.Header>
-              <ProgressiveTable.Body as={<Table.Body />}>
-                <ProgressiveTable.Row as={<Table.Row />}>
-                  <ProgressiveTable.Cell as={<Table.Cell />}>foo</ProgressiveTable.Cell>
-                </ProgressiveTable.Row>
-              </ProgressiveTable.Body>
-            </ProgressiveTable.Table>
+            <Table>
+              <Table.Header>
+                <Table.Row>
+                  <Table.HeaderCell>Dave</Table.HeaderCell>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                <Table.Row>
+                  <Table.Cell>foo</Table.Cell>
+                </Table.Row>
+              </Table.Body>
+            </Table>
           )
         );
       });
 
       renderStructureTests();
-
-      it('passes props to the asable component', () => {
-        expect(table()).toHaveProp('as', 'div');
-      });
-
-      it('renders asable components as prop passed to element in as prop', () => {
-        expect(table().find('div')).toHaveLength(1);
-      });
     });
 
     describe('when setting as props to semantic-ui table components', () => {
@@ -149,18 +141,18 @@ describe('ProgressiveTable', () => {
         setupComponent(
           { minimumRender: 10 },
           (
-            <ProgressiveTable.Table as={Table}>
-              <ProgressiveTable.Header as={Table.Header}>
-                <ProgressiveTable.Row as={Table.Row}>
-                  <ProgressiveTable.HeaderCell as={Table.HeaderCell}>Dave</ProgressiveTable.HeaderCell>
-                </ProgressiveTable.Row>
-              </ProgressiveTable.Header>
-              <ProgressiveTable.Body as={Table.Body}>
-                <ProgressiveTable.Row as={Table.Row}>
-                  <ProgressiveTable.Cell as={Table.Cell}>foo</ProgressiveTable.Cell>
-                </ProgressiveTable.Row>
-              </ProgressiveTable.Body>
-            </ProgressiveTable.Table>
+            <Table>
+              <Table.Header>
+                <Table.Row>
+                  <Table.HeaderCell>Dave</Table.HeaderCell>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                <Table.Row>
+                  <Table.Cell>foo</Table.Cell>
+                </Table.Row>
+              </Table.Body>
+            </Table>
           )
         );
       });

--- a/test/spec/progressive-table.js
+++ b/test/spec/progressive-table.js
@@ -197,10 +197,13 @@ describe('ProgressiveTable', () => {
     });
 
     describe('after second timer completed', () => {
+      let offsetHeight;
+
       beforeEach(() => {
         Object.defineProperty(instance.element, 'offsetHeight', {
-          get: () => 78
+          get: () => offsetHeight
         });
+        offsetHeight = 78;
         jest.runOnlyPendingTimers();
         component.update();
       });
@@ -256,12 +259,17 @@ describe('ProgressiveTable', () => {
 
       describe('after third timer completed and no more rows to render', () => {
         beforeEach(() => {
+          offsetHeight = 129;
           jest.runOnlyPendingTimers();
           component.update();
         });
 
         it('renders the same amount of rows', () => {
           expect(tableRows()).toHaveLength(4);
+        });
+
+        it('sets element minHeight to its current height', () => {
+          expect(minHeight()).toEqual('129px');
         });
       });
     });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,6 @@
 const path = require('path');
 const FlowPlugin = require('flow-babel-webpack-plugin');
 
-const mode = process.env.NODE_ENV === 'production' ? 'production' : 'none';
-
 const plugins = [
   'transform-runtime',
   'add-module-exports',
@@ -15,13 +13,14 @@ if (process.env.NODE_ENV === 'test') {
 }
 
 module.exports = {
-  mode,
+  mode: 'none',
   entry: ['./lib/progressive-table.js'],
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'index.js',
     libraryTarget: 'umd'
   },
+  externals: ['react', 'react-dom'],
   module: {
     rules: [
       {


### PR DESCRIPTION
This removes the need to use `react-render-as` in favour of setting the row node type using a prop (`tr`) which defaults to the standard HTML element. It also increases test and mutation coverage to 100%.